### PR TITLE
Fixed typos and made instructions copy paste

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@ Adds options to keep tabs on page (sticky tabs) and to move extensions into a hi
 ![image](https://github.com/xanthousm/text-gen-webui-ui_tweaks/assets/70198941/c5998420-9607-43d1-865f-65ec0f449ec2)
 
 ### Installation:
-- Clone this repository into the extensions folder
-- Rename the folder from ```text-gen-webui-ui_tweaks``` to ```ui_tweaks``` (or any name without '-' characters)
-- Activate it in the UI's inference mode tab, or by using the ```--extensions``` flag on launch.
+1. Make sure you're in the `text-generation-webui` directory and clone this repository directly into the `extensions` directory
+```bash
+git clone https://github.com/xanthousm/text-gen-webui-ui_tweaks.git extensions/ui_tweaks
+```
+2. Activate it in the UI's **Interface mode** tab, or by using the ```--extension``` flag on launch (e.g. `--extension ui_tweaks`).
 
 ### Sidebar settings:
 - Open sidebar on startup


### PR DESCRIPTION
Fixed a couple of typos and made the instructions similar to other text-gen extension instruction pages for easy copy paste 😃 